### PR TITLE
Skip j and add dates conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,3 @@ Convert Arabic betacode to transcription for OpenITI yml files
 Use it here: https://pverkind.github.io/betacodeTranscriber/
 
 Based on Maxim Romanov's Python script for Arabic betacode (see https://alraqmiyyat.github.io/2015/02-07.html)
-
-The tool is created by Peter Verkinderen. In this forked version the conversion of ج is removed.
-Additionally, years between hijri and gregorian calendars are automatically converted. For example, 1446AH is converted into 1446/2024 and 2024CE is converted into 1446/2024.

--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ Convert Arabic betacode to transcription for OpenITI yml files
 Use it here: https://pverkind.github.io/betacodeTranscriber/
 
 Based on Maxim Romanov's Python script for Arabic betacode (see https://alraqmiyyat.github.io/2015/02-07.html)
+
+The tool is created by Peter Verkinderen. In this forked version the conversion of ج is removed.
+Additionally, years between hijri and gregorian calendars are automatically converted. For example, 1446AH is converted into 1446/2024 and 2024CE is converted into 1446/2024.

--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
 <p>&nbsp;</p>
 </td>
 <td width="86">
-<p></p>
+<p>j</p>
 </td>
 <td width="79">
 <p>ج</p>

--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
 <p>&nbsp;</p>
 </td>
 <td width="86">
-<p>j ; ^g ; ǧ</p>
+<p></p>
 </td>
 <td width="79">
 <p>ج</p>

--- a/js/betacode.js
+++ b/js/betacode.js
@@ -5,20 +5,15 @@ var ar_check = document.getElementById("ar_check");
 
 function transliterate() {
   var text = beta.value;
-  
-  console.log("Before Date Conversion: " + text);  //FIXME
 
   text = convertDate(text);
 
-  console.log("After Date Conversion: " + text);  //FIXME
-
   if (ar_check.checked == true) {
     var ar = betacodeToArabic(text);
-    console.log('Converted to Arabic: ' + ar);  //FIXME
     arab.textContent = ar;
   }
+  
   var tr = betacodeToTranslit(text);
-  console.log('After transliteration: '+ tr);  //FIXME
   translit.value = tr;
 }
 

--- a/js/betacode.js
+++ b/js/betacode.js
@@ -5,18 +5,20 @@ var ar_check = document.getElementById("ar_check");
 
 function transliterate() {
   var text = beta.value;
-  //console.log(text);
+  
+  console.log("Before Date Conversion: " + text);  //FIXME
 
   text = convertDate(text);
 
+  console.log("After Date Conversion: " + text);  //FIXME
+
   if (ar_check.checked == true) {
     var ar = betacodeToArabic(text);
-    console.log('ar: '+ar);
+    console.log('Converted to Arabic: ' + ar);  //FIXME
     arab.textContent = ar;
   }
   var tr = betacodeToTranslit(text);
-  console.log("tr: "+tr);
-  //translit.textContent = tr;
+  console.log('After transliteration: '+ tr);  //FIXME
   translit.value = tr;
 }
 
@@ -98,7 +100,8 @@ var translitArabic = {
     'b' : ' ب ',  // bāʾ
     't' : ' ت ',  // tāʾ
     'ṯ' : ' ث ', // thāʾ
-    'ǧ' : ' ج ',  // jīm
+    // 'ǧ' : ' ج ',  // jīm
+    'j' : ' ج ',  // jīm
     'č' : ' چ ', // chīm / Persian
     'ḥ' : ' ح ',  // ḥāʾ
     'ḫ' : ' خ ', // khāʾ
@@ -182,13 +185,22 @@ function betacodeToTranslit(text) {
     return text
 }
 
+const arabicDigits = "٠١٢٣٤٥٦٧٨٩";
+
+
 function betacodeToArabic(text) {
     var cnsnnts = "btṯǧčḥḥḫdḏrzsšṣḍṭẓʿġfḳkglmnhwy";
     var cnsnnts = cnsnnts + cnsnnts.toUpperCase();
 
+    // convert dates to Arabic
+    const arabicDigits = "٠١٢٣٤٥٦٧٨٩";
+    const textArabicDigits = text.replace(/\d/g, (digit) => arabicDigits[digit]);
+    text =  textArabicDigits.replace(/(\d+)\s*\/\s*(\d+)/g, "$1 هـ / $2 م");
+
     // deal with shadda:
     shadda = "  ّ  ".trim();
-    text = text.replace(/(\w)\1/g, "$1"+shadda);
+    // it must match only letters (not numbers nor underscore)
+    text = text.replace(/([\p{L}])\1/gu, "$1" + shadda);
 
     // convert text:
 

--- a/js/betacode.js
+++ b/js/betacode.js
@@ -7,13 +7,14 @@ function transliterate() {
   var text = beta.value;
   //console.log(text);
 
+  text = convertDate(text);
+
   if (ar_check.checked == true) {
     var ar = betacodeToArabic(text);
     console.log('ar: '+ar);
     arab.textContent = ar;
   }
   var tr = betacodeToTranslit(text);
-  tr = convertDate(tr);
   console.log("tr: "+tr);
   //translit.textContent = tr;
   translit.value = tr;
@@ -364,7 +365,7 @@ function convertDate(text) {
 
     text = text.replace(cePattern, (match, ceYear) => {
         const ahYear = CEAH(parseInt(ceYear, 10));
-        return `${ahYear}AH/${ceYear}CE`;
+        return `${ahYear}/${ceYear}`;
     });
 
     text = text.replace(ahPattern, (match, ahYear) => {

--- a/js/betacode.js
+++ b/js/betacode.js
@@ -13,6 +13,7 @@ function transliterate() {
     arab.textContent = ar;
   }
   var tr = betacodeToTranslit(text);
+  tr = convertDate(tr);
   console.log("tr: "+tr);
   //translit.textContent = tr;
   translit.value = tr;
@@ -44,8 +45,8 @@ var betacodeTranslit = {
     'b'  : 'b', // bā’
     't'  : 't', // tā’
     '_t' : 'ṯ', // thā’
-    '^g' : 'ǧ', // jīm
-    'j'  : 'ǧ', // jīm
+    // '^g' : 'ǧ', // jīm
+    // 'j'  : 'ǧ', // jīm
     '^c' : 'č', // chīm / Persian
     '*h' : 'ḥ', // ḥā’
     '_h' : 'ḫ', // khā’
@@ -340,6 +341,36 @@ function betacodeToArabic(text) {
     text = text.replace(/,/g, "،"); // Convert commas
     text = text.replace(/-|_|ـ/g, "")
 
+
+    return text;
+}
+
+
+function AHCE(dateAH) {
+    let data = dateAH - dateAH / 33 + 622;
+    return Math.round(data).toString();
+}
+
+
+function CEAH(dateCE) {
+    let data = (33 / 32) * (dateCE - 622);
+    return Math.round(data).toString();
+}
+
+
+function convertDate(text) {
+    const cePattern = /(?<!\d\/)(\d{1,4})CE(?!\/\d)/g;
+    const ahPattern = /(\d{1,4})AH(?!\/\d)/g;
+
+    text = text.replace(cePattern, (match, ceYear) => {
+        const ahYear = CEAH(parseInt(ceYear, 10));
+        return `${ahYear}AH/${ceYear}CE`;
+    });
+
+    text = text.replace(ahPattern, (match, ahYear) => {
+        const ceYear = AHCE(parseInt(ahYear, 10));
+        return `${ahYear}/${ceYear}`;
+    });
 
     return text;
 }


### PR DESCRIPTION
I disable the conversion of j into ǧ and ^g  into j.

I also added an automatic conversion of hijri years to gregorian years and vice versa. For example "446AH" is automatically converted to 446/1054 and 1054CE into 446AH/1054CE.